### PR TITLE
#1862  - UX changes to add post title

### DIFF
--- a/app/main/posts/modify/post-editor.html
+++ b/app/main/posts/modify/post-editor.html
@@ -52,7 +52,7 @@
 
           <div class="form-sheet">
               <div class="post-band" ng-style="{backgroundColor: form.color}"></div>
-              <div class="form-field title init required"
+              <div class="form-field init required"
               adaptive-form
               ng-class="{
                 'error': postForm.title.$invalid && postForm.title.$dirty,


### PR DESCRIPTION
Improved the layout of the post title in the add post page. Achieved by removing the title class from the element that holds the title text. Removing the title class removes associated 0 margins and aligns the title element with other elements on the form. 